### PR TITLE
Fix issue13198 PROFILING fast BitBlt

### DIFF
--- a/platforms/Cross/plugins/BitBltPlugin/BitBltDispatch.c
+++ b/platforms/Cross/plugins/BitBltPlugin/BitBltDispatch.c
@@ -418,12 +418,13 @@ void copyBitsDispatch(operation_t *op)
 		storedCombinationRule = op->combinationRule;
 		storedFlags = flags;
 		storedFunc = lookupFastPath(op->combinationRule, flags);
-		if (storedFunc == NULL)
+		if (storedFunc == NULL) {
 			/* Unsupported case 8 */
 #ifdef PROFILING
 			profile_unrecorded_cases[8]++;
 #endif
 			storedFunc = copyBitsFallback;
+		}
 	}
 #ifdef PROFILING
 	uint32_t before = gettime();


### PR DESCRIPTION
This is not really urgent because you generally don't def PROFILING, but it's an easy one
See https://pharo.fogbugz.com/f/cases/13198/BitBlt-PROFILING-option-ruins-the-fast-copyBits-loop
