### PR TITLE
Fix issue13199 i386/iphone inversion of arguments in atomic swap MACRO

### DIFF
--- a/platforms/Cross/vm/sqAtomicOps.h
+++ b/platforms/Cross/vm/sqAtomicOps.h
@@ -212,7 +212,7 @@ AtomicGet(uint64_t *target)
 #ifdef TARGET_OS_IS_IPHONE
 # define sqCompareAndSwap(var,old,new) OSAtomicCompareAndSwap32(old, new, &var) 
 /* N.B.  This is not atomic in fetching var's old value :( */
-# define sqCompareAndSwapRes(var,new,old,res) do { res = var; if (OSAtomicCompareAndSwap32(old, new, &var)) res = new; } while (0)
+# define sqCompareAndSwapRes(var,old,new,res) do { res = var; if (OSAtomicCompareAndSwap32(old, new, &var)) res = new; } while (0)
 #else
 # define sqCompareAndSwap(var,old,new) \
 	asm volatile ("movl %1, %%eax; lock cmpxchg %2, %0" \


### PR DESCRIPTION
I don't know in which case mixing i386 & TARGET_OS_IS_IPHONE applies, but we cannot let this stinky inversion in place IMO...
See https://pharo.fogbugz.com/f/cases/13199/Stinky-argument-inversion-of-atomic-swap-MACRO-for-iphone-gcc-branch
