### PR TITLE
Use pthread_atfork to reinstall the heartbeat thread post fork.

### DIFF
--- a/platforms/unix/vm/sqUnixHeartbeat.c
+++ b/platforms/unix/vm/sqUnixHeartbeat.c
@@ -328,7 +328,9 @@ heartbeat()
 
 typedef enum { dead, condemned, nascent, quiescent, active } machine_state;
 
-static int					stateMachinePolicy;
+#define UNDEFINED 0xBADF00D
+
+static int					stateMachinePolicy = UNDEFINED;
 static struct sched_param	stateMachinePriority;
 
 static volatile machine_state beatState = nascent;
@@ -379,19 +381,30 @@ ioInitHeartbeat()
 	struct timespec halfAMo;
 	pthread_t careLess;
 
-	if ((er = pthread_getschedparam(pthread_self(),
-									&stateMachinePolicy,
-									&stateMachinePriority))) {
-		errno = er;
-		perror("pthread_getschedparam failed");
-		exit(errno);
-	}
-	++stateMachinePriority.sched_priority;
-	/* If the priority isn't appropriate for the policy (typically SCHED_OTHER)
-	 * then change policy.
+	/* First time through choose a policy and priority for the heartbeat thread,
+	 * and install ioInitHeartbeat via pthread_atfork to be run again in a forked
+	 * child, restarting the heartbeat in a forked child.
 	 */
-	if (sched_get_priority_max(stateMachinePolicy) < stateMachinePriority.sched_priority)
-		stateMachinePolicy = SCHED_FIFO;
+	if (stateMachinePolicy == UNDEFINED) {
+		if ((er = pthread_getschedparam(pthread_self(),
+										&stateMachinePolicy,
+										&stateMachinePriority))) {
+			errno = er;
+			perror("pthread_getschedparam failed");
+			exit(errno);
+		}
+		assert(stateMachinePolicy != UNDEFINED);
+		++stateMachinePriority.sched_priority;
+		/* If the priority isn't appropriate for the policy (typically
+		 * SCHED_OTHER) then change policy.
+		 */
+		if (sched_get_priority_max(stateMachinePolicy) < stateMachinePriority.sched_priority)
+			stateMachinePolicy = SCHED_FIFO;
+		pthread_atfork(0, /*prepare*/ 0, /*parent*/ ioInitHeartbeat /*child*/);
+	}
+	else /* subsequently (in the child) init beatState before creating thread */
+		beatState = nascent;
+
 	halfAMo.tv_sec  = 0;
 	halfAMo.tv_nsec = 1000 * 100;
 	if ((er= pthread_create(&careLess,


### PR DESCRIPTION
David Lewis suggested:
On Wed, May 21, 2014 at 04:35:33PM +0200, Stephan Eggermont wrote: 

> PetitParser 1.6 instead of 1.5. 
> Tests only work when no Nautilus browser is open. Some notification problem when creating classes. 
> 
> OSProcess ci has lots of failing tests, so we don't know if it actually works??? 
> 
> Diego & Stephan 

The tests for OSProcess require VM support. Until recently, an interpreter VM was 
required to run the full OSProcess test suite because it relies heavily on #forkSqueak 
to generate cooperating VM processes for the tests. 

Eliot has recently added an enhancement to Cog that provides the required support. When 
that change is added to the Pharo VM, the tests will run. 

The changes are in SVN in branches/Cog/platforms/unix/vm/ and the commit notice is at: 

http://lists.squeakfoundation.org/pipermail/vm-dev/2014-March/014964.html
