### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/platforms/unix/vm/glibc.h
+++ b/platforms/unix/vm/glibc.h
@@ -1,4 +1,4 @@
-#include <features.h>
+#include <stdint.h>
 #if defined(__GNUC__) && defined(__GLIBC_PREREQ)
 # if __GLIBC_PREREQ(2,3)
     /* squash __ctype_to{upper,lower}_loc and avoid including the header */

--- a/platforms/unix/vm/sqUnixMain.c
+++ b/platforms/unix/vm/sqUnixMain.c
@@ -889,7 +889,7 @@ printRegisterState(ucontext_t *uap)
 			regs[REG_EIP]);
 	return regs[REG_EIP];
 #elif __FreeBSD__ && __i386__
-	struct mcontext *regs = &uap->uc_mcontext;
+	mcontext_t *regs = &uap->uc_mcontext;
 	printf(	"\teax 0x%08x ebx 0x%08x ecx 0x%08x edx 0x%08x\n"
 			"\tedi 0x%08x esi 0x%08x ebp 0x%08x esp 0x%08x\n"
 			"\teip 0x%08x\n",


### PR DESCRIPTION
The trick to detect if the VM is compiled on GNU libc only works on GNU libc and the context is named differently on FreeBSD.
