### PR TITLE
Case14521

### DIFF
--- a/platforms/iOS/vm/Common/Classes/sqSqueakMainApplication+events.m
+++ b/platforms/iOS/vm/Common/Classes/sqSqueakMainApplication+events.m
@@ -73,6 +73,7 @@
 	ioProcessEvents();
 	id event = [eventQueue returnAndRemoveOldest];
 	if (event) {
+		NSLog(@"ioGetNextEvent:");
 		NSAutoreleasePool * pool = [NSAutoreleasePool new];
 		[self processAsOldEventOrComplexEvent: event placeIn: evt];
 		[event release];

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -157,6 +157,7 @@ static int buttonState=0;
 
 - (void) pushEventToQueue: (sqInputEvent *) evt {	
 	NSMutableArray* data = [NSMutableArray new];
+
 	NSLog(@"sqSqueakOSXApplication+events.m>>pushEventToQueue:");
 	[data addObject: [NSNumber numberWithInteger: 1]];
 	[data addObject: [NSData  dataWithBytes:(const void *) evt length: sizeof(sqInputEvent)]];
@@ -227,6 +228,22 @@ static int buttonState=0;
 	
 	interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
 
+}
+
+- (void) recordKeyDownEvent:(NSEvent *)theEvent fromView: (NSView<sqSqueakOSXView>*) aView {
+	sqKeyboardEvent evt;
+	
+	evt.type = EventTypeKeyboard;
+	evt.timeStamp = (int) ioMSecs();
+	evt.charCode =	[theEvent keyCode];
+	evt.pressCode = EventKeyDown;
+	evt.modifiers = [self translateCocoaModifiersToSqueakModifiers: [theEvent modifierFlags]];
+	evt.utf32Code = 0;
+	evt.reserved1 = 0;
+	evt.windowIndex = (int)[[aView windowLogic] windowIndex];
+	[self pushEventToQueue: (sqInputEvent *) &evt];
+
+	interpreterProxy->signalSemaphoreWithIndex(gDelegateApp.squeakApplication.inputSemaphoreIndex);
 }
 
 - (void) recordKeyUpEvent:(NSEvent *)theEvent fromView: (NSView<sqSqueakOSXView>*) aView {

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -149,7 +149,7 @@ static int buttonState=0;
 	if ([[event objectAtIndex: 0] intValue] == 1) {
 		[(NSData *)[event objectAtIndex: 1] getBytes: evt length: sizeof(sqInputEvent)];
 		if (evt->type == EventTypeKeyboard) {
-//			NSLog(@"keyboard pc %i cc %i uc %i m %i",((sqKeyboardEvent *)evt)->pressCode,((sqKeyboardEvent *) evt)->charCode,((sqKeyboardEvent *) evt)->utf32Code,((sqKeyboardEvent *) evt)->modifiers);
+			NSLog(@"keyboard pc %i cc %i uc %i m %i",((sqKeyboardEvent *)evt)->pressCode,((sqKeyboardEvent *) evt)->charCode,((sqKeyboardEvent *) evt)->utf32Code,((sqKeyboardEvent *) evt)->modifiers);
 		}
 		return;
 	}
@@ -157,6 +157,7 @@ static int buttonState=0;
 
 - (void) pushEventToQueue: (sqInputEvent *) evt {	
 	NSMutableArray* data = [NSMutableArray new];
+	NSLog(@"sqSqueakOSXApplication+events.m>>pushEventToQueue:");
 	[data addObject: [NSNumber numberWithInteger: 1]];
 	[data addObject: [NSData  dataWithBytes:(const void *) evt length: sizeof(sqInputEvent)]];
 	[eventQueue addItem: data];
@@ -171,6 +172,7 @@ static int buttonState=0;
 	NSRange picker;
 	NSUInteger totaLength;
 	
+	NSLog(@"sqSqueakOSXApplication+events>>recordCharEvent:fromView:");
 	evt.type = EventTypeKeyboard;
 	evt.timeStamp = (int) ioMSecs();
 	picker.location = 0;

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -357,6 +357,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	aKeyBoardStrokeDetails.modifierFlags = [theEvent modifierFlags];
 	
 	NSArray *down = [[NSArray alloc] initWithObjects: theEvent,nil];
+	NSLog(@"sqSqueakOSXCGView.m>>keyDown:");
 	@synchronized(self) {
 		lastSeenKeyBoardStrokeDetails = aKeyBoardStrokeDetails;
 		[self interpretKeyEvents: down];
@@ -373,15 +374,18 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 
 - (void)insertText:(id)aString
 {
+	NSLog(@"sqSqueakOSXCGView.m>>insertText:");
 	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordCharEvent: aString fromView: self];
 }
 
 - (void)insertText:(id)aString replacementRange:(NSRange)replacementRange
 {
+	NSLog(@"sqSqueakOSXCGView.m>>insertText:replacementRange:");
 	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordCharEvent: aString fromView: self];
 }
 
 - (void)flagsChanged:(NSEvent *)theEvent {
+	NSLog(@"sqSqueakOSXCGView.m>>flagsChanged -- %d, %d", [theEvent keyCode], [theEvent modifierFlags] );
 	keyBoardStrokeDetails *aKeyBoardStrokeDetails = [[keyBoardStrokeDetails alloc] init];
 	aKeyBoardStrokeDetails.keyCode = [theEvent keyCode];
 	aKeyBoardStrokeDetails.modifierFlags = [theEvent modifierFlags];

--- a/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXCGView.m
@@ -339,6 +339,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	NSArray *down = [[NSArray alloc] initWithObjects: theEvent,nil];
 	@synchronized(self) {
 		lastSeenKeyBoardStrokeDetails = aKeyBoardStrokeDetails;
+
 		NSString *possibleConversion = [theEvent characters];
 		
 		if ([possibleConversion length] > 0) {
@@ -375,6 +376,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 - (void)insertText:(id)aString
 {
 	NSLog(@"sqSqueakOSXCGView.m>>insertText:");
+
 	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordCharEvent: aString fromView: self];
 }
 
@@ -390,6 +392,7 @@ lastSeenKeyBoardModifierDetails,dragInProgress,dragCount,dragItems,windowLogic,s
 	aKeyBoardStrokeDetails.keyCode = [theEvent keyCode];
 	aKeyBoardStrokeDetails.modifierFlags = [theEvent modifierFlags];
 	self.lastSeenKeyBoardModifierDetails = aKeyBoardStrokeDetails;
+	[(sqSqueakOSXApplication *) gDelegateApp.squeakApplication recordKeyDownEvent: theEvent fromView: self];
 	[aKeyBoardStrokeDetails release];
 }
 


### PR DESCRIPTION
On OSX, allow modifier key presses (shift, ctrl, etc) to be passed through to image as individual events (same as works for Linux & Win32). Case 14251 (https://pharo.fogbugz.com/default.asp?14521).

I'll clean away the inserted NSLog after discussion.
