### PR TITLE
misc: Fix trivial compiler warnings

### DIFF
--- a/platforms/Cross/plugins/Mpeg3Plugin/libmpeg/changesForSqueak.c
+++ b/platforms/Cross/plugins/Mpeg3Plugin/libmpeg/changesForSqueak.c
@@ -34,6 +34,7 @@
 // May 31st, 2002 JMM a few additions to make it compile on the mac with latest code
 
 #include <string.h>
+#include <stdlib.h>
 #include "mpeg3private.h"
 #include "changesForSqueak.h"
 

--- a/platforms/Cross/vm/sqHeapMap.c
+++ b/platforms/Cross/vm/sqHeapMap.c
@@ -22,6 +22,7 @@
 #include "sqMemoryAccess.h" 
 
 #include <stdlib.h>
+#include <string.h>
 
 #define ulong unsigned long
 #define uchar unsigned char

--- a/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
+++ b/platforms/unix/plugins/DropPlugin/sqUnixDragDrop.c
@@ -71,7 +71,7 @@ int dropRequestFileHandle(int dropIndex)
     {
       // you cannot be serious?
       int handle= instantiateClassindexableSize(classByteArray(), fileRecordSize());
-      sqFileOpen((SQFile *)fileValueOf(handle), (int)path, strlen(path), 0);
+      sqFileOpen((SQFile *)fileValueOf(handle), path, strlen(path), 0);
       return handle;
     }  
   return interpreterProxy->nilObject();

--- a/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.c
+++ b/platforms/unix/plugins/SqueakSSL/sqUnixOpenSSL.c
@@ -12,7 +12,7 @@ typedef struct sqSSL {
 	char *certName;
 	char *peerName;
 
-	SSL_METHOD *method;
+	const SSL_METHOD *method;
 	SSL_CTX *ctx;
 	SSL *ssl;
 	BIO *bioRead;

--- a/platforms/unix/vm/debug.c
+++ b/platforms/unix/vm/debug.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
+#include <stdlib.h>
 
 void __sq_DPRINTF(const char *fmt, ...)
 {


### PR DESCRIPTION
Include stdlib.h for abort, free and string for memset, make the
argument const.
