### PR TITLE
Fake mouse wheel events with all modifier keys pressed (not just ctrl)

### DIFF
--- a/platforms/Mac OS/vm/sqMacUIEvents.c
+++ b/platforms/Mac OS/vm/sqMacUIEvents.c
@@ -1872,7 +1872,7 @@ void fakeMouseWheelKeyboardEvents(EventMouseWheelAxis wheelMouseDirection,long w
 	/* press code must differentiate */
 	evt->charCode = macKeyCode;
 	evt->pressCode = EventKeyDown;
-	evt->modifiers = modifierMap[(controlKey >> 8)];
+	evt->modifiers = modifierMap[((controlKey | optionKey | cmdKey | shiftKey) >> 8)];
 	evt->windowIndex = windowActive;
 	/* generate extra character event */
         extra = (sqKeyboardEvent*)nextEventPut();

--- a/platforms/Mac OS/vm/sqMacUIEventsUniversal.c
+++ b/platforms/Mac OS/vm/sqMacUIEventsUniversal.c
@@ -1097,7 +1097,7 @@ fakeMouseWheelKeyboardEvents(EventMouseWheelAxis wheelMouseDirection,long wheelM
 	evt->charCode = macKeyCode;
 	evt->pressCode = EventKeyDown;
 	evt->utf32Code = 0;
-	evt->modifiers = modifierMap[(controlKey >> 8)];
+	evt->modifiers = modifierMap[((controlKey | optionKey | cmdKey | shiftKey) >> 8)];
 	evt->windowIndex = windowActive;
 	/* generate extra character event */
         extra = (sqKeyboardEvent*)nextEventPut();

--- a/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
+++ b/platforms/iOS/vm/OSX/sqSqueakOSXApplication+events.m
@@ -311,7 +311,7 @@ static int buttonState=0;
 	evt.charCode = keyCode;
 	evt.utf32Code = 0;
 	evt.reserved1 = 0;
-	evt.modifiers = modifierMap[(controlKey >> 8)];
+	evt.modifiers = modifierMap[((controlKey | optionKey | cmdKey | shiftKey) >> 8)];
 	evt.windowIndex = windowIndex;
 	[self pushEventToQueue:(sqInputEvent *) &evt];
 


### PR DESCRIPTION
Recently, we discovered that the key combination used to fake wheel events - ctrl + arrowKey - may be a bit too simple. Apparently ctrl+horizontalArrowKey is a standard in-use combo in Linux and Windows, so adding horizontal wheel events broke some users' workflows. So I propose "ctrl + alt + shift + cmd + arrowKey".
The new combo is:
- very unlikely to be typed
- backward-compatible with existing Pharo and Squeak images, which only checks that either cmd or ctrl is pressed
- frees up ctrl + arrow for our Linux/Windows friends

There is an accompanying Fogbugz Issue 15209: "Mouse Wheel Events Keyboard Clash", with a slice all ready on the image side once this is integrated.

NB: I changed the combo for Mac OS and OSX. Are these the only two platforms that fake wheel events? I searched a bit but didn't see similar logic for other platforms...
