### PR TITLE
fix some typos in SpurMemoryManager README.md

### DIFF
--- a/mc/VMMaker.oscog.package/SpurMemoryManager.class/README.md
+++ b/mc/VMMaker.oscog.package/SpurMemoryManager.class/README.md
@@ -83,7 +83,7 @@ Instance Variables
 
 becomeEffectsFlags
 	- a set of flags to limit the work done during become; one of BecameCompiledMethodFlag, BecamePointerObjectFlag
-	
+
 checkForLeaks
 	- a set of flags determining when to run leak checks on the heap's contents
 
@@ -126,11 +126,11 @@ freeLists
 	  freeLists is the firstIndexableField of the fourth object in oldSpace.
 
 freeListsMask
-	- a bitmap of flags with a 1 set whereever the freeLists has a non-empty entry, used to limit the search for free chunks
+	- a bitmap of flags with a 1 set wherever the freeLists has a non-empty entry, used to limit the search for free chunks
 
 freeOldSpaceStart
 	- the last used address in oldSpace.  The space between freeOldSpaceStart and endOfMemory can be used for oldSpace allocations.
-	  Given freeLists this probably isn't useful and shoud be discarded in favouf of endOfMemory.
+	  Given freeLists this probably isn't useful and should be discarded in favouf of endOfMemory.
 
 freeStart
 	- the last used address in eden.  this is where new objects are allocated if there is room in eden.
@@ -159,7 +159,7 @@ lastHash
 	- the last object hash value.  a pseudo-random number generator.
 
 lowSpaceThreshold
-	- the ammount of free memory below which the low space condition should be signalled.
+	- the amount of free memory below which the low space condition should be signaled.
 
 marking
 	- a flag set and cleared in markAccessibleObjects to allow ensureRoomOnObjStackAtIndex: to know whether to mark a new obj stack page or not.
@@ -196,7 +196,7 @@ pastSpaceStart
 
 remapBuffer
 	- an Array of objects used to implement pushRemappableOop: et al for compatibility with ObjectMemory.
-	  Its functionality isnt needed because Spur will never GC during allocation.  But it muts be present and
+	  Its functionality isn't needed because Spur will never GC during allocation.  But it muts be present and
 	  correct, otherwise many primitives that use pushRemappableOop: et al would have to be rewritten.
 
 remapBufferCount
@@ -229,7 +229,7 @@ statFGCDeltaUsecs statFullGCUsecs statFullGCs statGCEndUsecs statGrowMemory stat
 
 totalFreeOldSpace
 	- the total free space on the free lists
-	
+
 trueObj
 	- the oop of the false object; must be the third object in oldSpace
 
@@ -263,7 +263,7 @@ The design objectives for the Spur memory manager are
 			enter replacement in class table
 behaviorHash is a special version of identityHash that must be implemented in the image by any object that can function as a class (i.e. Behavior).
 
-- more immediate classes.  An immediate Character class would speed up String accessing, especially for WideString, since no instatiation needs to be done on at:put: and no dereference need be done on at:.  In a 32-bit system tag checking is complex since it is thought important to retain 31-bit SmallIntegers.  Hence, as in current Squeak, the least significant bit set implies a SmallInteger, but Characters would likely have a tag pattern of xxx10.  Hence masking with 11 results in two values for SmallInteger, xxx01 and xxx11 (for details see In-line cache probe for immediates below).  30-bit characters are more than adequate for Unicode.  In a 64-bit system we can use the full three bits and usefully implement an immediate Float.  As in VisualWorks a functional representation takes three bits away from the exponent.  Rotating to put the sign bit in the least significant non-tag bit makes expanding and contracting the 8-bit exponent to the 11-bit IEEE double exponent easy and makes comparing negative and positive zero easier (an immediate Float is zero if its unsigned 64-bits are < 16).  So the representation looks like
+- more immediate classes.  An immediate Character class would speed up String accessing, especially for WideString, since no instantiation needs to be done on at:put: and no dereference need be done on at:.  In a 32-bit system tag checking is complex since it is thought important to retain 31-bit SmallIntegers.  Hence, as in current Squeak, the least significant bit set implies a SmallInteger, but Characters would likely have a tag pattern of xxx10.  Hence masking with 11 results in two values for SmallInteger, xxx01 and xxx11 (for details see In-line cache probe for immediates below).  30-bit characters are more than adequate for Unicode.  In a 64-bit system we can use the full three bits and usefully implement an immediate Float.  As in VisualWorks a functional representation takes three bits away from the exponent.  Rotating to put the sign bit in the least significant non-tag bit makes expanding and contracting the 8-bit exponent to the 11-bit IEEE double exponent easy and makes comparing negative and positive zero easier (an immediate Float is zero if its unsigned 64-bits are < 16).  So the representation looks like
 	| 8 bit exponent | 52 bit mantissa | sign bit | 3 tag bits |
 For details see "60-bit immediate Floats" below.
 
@@ -312,7 +312,7 @@ To provide pinning in old space, large objects are implicitly pinned (because it
 Free space in old space is organized by a number of free lists and a free tree .  There are 32 or 64 free lists, depending on word size, indices 1 through wordSize - 1 holding blocks of space of the index * allocationUnit, index 0 holding a semi-balanced ordered tree of free blocks, each node being the head of the list of free blocks of that size.  At the start of the mark phase the free list is thrown away and the sweep phase coalesces free space and steps over pinned objects as it proceeds.  We can reuse the forwarding pointer compaction scheme used in the old collector.  Incremental collections merely move unmarked objects to the free lists (as well as nilling weak pointers in weak arrays and scheduling them for finalization).  The occupancy of the free lists is represented by a bitmap in an integer so that an allocation of size wordSize - 1 or less can know whether there exists a free chunk of that size, but more importantly can know whether a free chunk larger than it exists in the fixed size free lists without having to search all larger free list heads.
 
 Incremental Old Space Collection
-The incremental collector (a la Dijkstra's three colour algorithm) collects old space via an amount of tracing being hung off scavenges and/or old space allocations at an adaptive rate that keeps full garbage collections to a minimum.  [N.B. Not sure how to do this yet.  The incremental collector needs to complete a pass often enough to reclaim objects, but infrequent enough not to waste time.  So some form of feedback should work.  In VisualWorks tracing is broken into quanta or work where image-level code determines the size of a quantum based on how fast the machine is, and how big the heap is.  This code could easily live in the VM, controllable through vmParameterAt:put:.  An alternative would be to use the heartbeat to bound quanta by time.  But in any case some amount of incremental collection would be done on old space allocation and scavenging, the ammount being chosen to keep pause times acceptably short, and at a rate to reclaim old space before a full GC is required, i.e. at a rate proportional to the growth in old space]. The incemental collector is a state machine, being either marking, nilling weak pointers, or freeing.  If nilling weak pointers is not done atomically then there must be a read barrier in weak array at: so that reading from an old space weak array that is holding stale un-nilled references to unmarked objects.  Tricks such as including the weak bit in bounds calculations can make this cheap for non-weak arrays.  Alternatively nilling weak pointers can be made an atomic part of incremental collection, which can be made cheaper by maintaining the set of weak arrays (e.g. on a list).  Note that the incremental collector also follows (and eliminates) forwarding pointers as it scans.
+The incremental collector (a la Dijkstra's three colour algorithm) collects old space via an amount of tracing being hung off scavenges and/or old space allocations at an adaptive rate that keeps full garbage collections to a minimum.  [N.B. Not sure how to do this yet.  The incremental collector needs to complete a pass often enough to reclaim objects, but infrequent enough not to waste time.  So some form of feedback should work.  In VisualWorks tracing is broken into quanta or work where image-level code determines the size of a quantum based on how fast the machine is, and how big the heap is.  This code could easily live in the VM, controllable through vmParameterAt:put:.  An alternative would be to use the heartbeat to bound quanta by time.  But in any case some amount of incremental collection would be done on old space allocation and scavenging, the amount being chosen to keep pause times acceptably short, and at a rate to reclaim old space before a full GC is required, i.e. at a rate proportional to the growth in old space]. The incremental collector is a state machine, being either marking, nilling weak pointers, or freeing.  If nilling weak pointers is not done atomically then there must be a read barrier in weak array at: so that reading from an old space weak array that is holding stale un-nilled references to unmarked objects.  Tricks such as including the weak bit in bounds calculations can make this cheap for non-weak arrays.  Alternatively nilling weak pointers can be made an atomic part of incremental collection, which can be made cheaper by maintaining the set of weak arrays (e.g. on a list).  Note that the incremental collector also follows (and eliminates) forwarding pointers as it scans.
 
 The incremental collector implies a more complex write barrier.  Objects are of three colours, black, having been scanned, grey, being scanned, and white, unreached.  A mark stack holds the grey objects.   If the incremental collector is marking and an unmarked white object is stored into a black object then the stored object must become grey, being added to the mark stack.  So the wrte barrier is essentially
 	target isYoung ifFalse:
@@ -344,14 +344,14 @@ A segmented oldSpace is useful.  It allows growing oldSpace incrementally, addin
 
 Lazy become & the become read barrier (see http://www.mirandabanda.org/cogblog/2013/09/13/lazy-become-and-a-partial-read-barrier/ & http://www.mirandabanda.org/cogblog/2014/02/08/primitives-and-the-partial-read-barrier/).
 
-As described earlier the basic idea behind lazy become is to use corpses (forwarding objects) that are followed lazily during GC and inline cache miss.  However, a lazy scheme would appear to require a read barrier to avoid accessing the coirpse and mak sure wel follow the forwarding pointer.  Without hardware support read barriers have poor performance, so we must restrict the read barrier as much as possible.  The main goal is to avoid having to scan all of the heap to fix up pointers, as is done with ObjectMemory.  We're happy to do some scanning of a small subset oif the heap, but become: cannot scale to large heaps if it must scan the entire heap.  Objects with named inst vars and CompiledMethods are accessed extensively by the interpreter and jitted code.  We must avoid as much checking of such accesses as possible; We judge an explicit read barrier on all accesses far too expensive.  The accesses the VM makes which notionally require a read barrier are:
+As described earlier the basic idea behind lazy become is to use corpses (forwarding objects) that are followed lazily during GC and inline cache miss.  However, a lazy scheme would appear to require a read barrier to avoid accessing the coirpse and make sure well follow the forwarding pointer.  Without hardware support read barriers have poor performance, so we must restrict the read barrier as much as possible.  The main goal is to avoid having to scan all of the heap to fix up pointers, as is done with ObjectMemory.  We're happy to do some scanning of a small subset oif the heap, but become: cannot scale to large heaps if it must scan the entire heap.  Objects with named inst vars and CompiledMethods are accessed extensively by the interpreter and jitted code.  We must avoid as much checking of such accesses as possible; We judge an explicit read barrier on all accesses far too expensive.  The accesses the VM makes which notionally require a read barrier are:
 - inst vars of thisContext, including stack contents (the receiver of a message and its arguments), which in Cog are the fields of the current stack frame, and the sender chain during (possibly non-local) return
 - named inst vars of the receiver
 - literals of the current method, in particular variable bindings (a.k.a. literal variables which are global associations), including the methodClass association.
 - in primitives, the receiver and arguments, including possible sub-structure.
 We have already discussed that we will catch an attempt to create a new activation on a forwarded object therough method lookup failing for forwarded objects.  This would occur when e.g. some object referenced by the receiver via its inst vars is pushed on the stack as a message receiver, or e.g. answered as the result of some primtiive which accesses object state such as primtive at:  So there is no need for a read barrier when accessing a new receiver or returning its state.  But there must presumably be a read barrier in primitives that inspect that sub-state.
 
-However, we can easily avoid read barriers in direct literal access, and class hierarchy walking and message dictionary searching in message lookup.  Whenever the become operation becomes one or more pointer objects (and it can e.g. cheaply know if it has becommed a CompiledMethod) both the class table and the stack zone are scanned.  In the class table we can follow the forwarding pointers in all classes in the table, and we can follow their superclasses.  But we would like to avoid scanning classes many times.  Any superclass that has a non-zero hash must be in the table and will be encountered during the scan of the class table.  Any superclass with a zero hash can be entered into the table at a point subsequent to the current index and hence scanned.  The class scan can also scan method dictionary selectors and follow the methiod dictionary's array reference (so that dictionaries are valid for lookup) and scan the dictionary's method array iff a CompiledMethod was becommed. (Note that support for object-as-method implies an explicit read barrier in primitiveObjectAsMethod, which is a small overhead there-in).
+However, we can easily avoid read barriers in direct literal access, and class hierarchy walking and message dictionary searching in message lookup.  Whenever the become operation becomes one or more pointer objects (and it can e.g. cheaply know if it has becommed a CompiledMethod) both the class table and the stack zone are scanned.  In the class table we can follow the forwarding pointers in all classes in the table, and we can follow their superclasses.  But we would like to avoid scanning classes many times.  Any superclass that has a non-zero hash must be in the table and will be encountered during the scan of the class table.  Any superclass with a zero hash can be entered into the table at a point subsequent to the current index and hence scanned.  The class scan can also scan method dictionary selectors and follow the method dictionary's array reference (so that dictionaries are valid for lookup) and scan the dictionary's method array iff a CompiledMethod was becomed. (Note that support for object-as-method implies an explicit read barrier in primitiveObjectAsMethod, which is a small overhead there-in).
 
 Accessing possibly forwarded method literals is fine; these forwarding objects will be pushed on the stack and caught either by the message lookup trap or explicitly in primitives that access arguments.  However, push/store/pop literal variable cannot avoid an explicit check without requiring we scan all methods, which will be far too expensive.  To avoid a check on super send when accessing a method's method class association, we must check the method class associations of any method in the stack zone, and in the method of any context faulted into the stack zone on return.
 
@@ -368,45 +368,45 @@ One approach would be an explicit call in the primitive, made convenient via pro
 Another approach would be to put an explicit read barrier in store/fetchPointer:ofObject:[withValue:] et al, but provide an additional api (e.g. store/fetchPointer:ofNonForwardedObject:[withValue:] et al) and use it in the VM's internals.  The former approach is error-prone, but the latter approach is potentially ugly, touching nearly all of the core VM code.  It would appear that one of these two approaches must be chosen.
 
 61-bit immediate Floats
-Representation for immediate doubles, only used in the 64-bit implementation. Immediate doubles have the same 52 bit mantissa as IEEE double-precision  floating-point, but only have 8 bits of exponent.  So they occupy just less than the middle 1/8th of the double range.  They overlap the normal single-precision floats which also have 8 bit exponents, but exclude the single-precision denormals (exponent-127) and the single-precsion NaNs (exponent +127).  +/- zero is just a pair of values with both exponent and mantissa 0. 
-So the non-zero immediate doubles range from 
-        +/- 0x3800,0000,0000,0001 / 5.8774717541114d-39 
-to      +/- 0x47ff,ffff,ffff,ffff / 6.8056473384188d+38 
-The encoded tagged form has the sign bit moved to the least significant bit, which allows for faster encode/decode because offsetting the exponent can't overflow into the sign bit and because testing for +/- 0 is an unsigned compare for <= 0xf: 
-    msb                                                                                        lsb 
-    [8 exponent subset bits][52 mantissa bits ][1 sign bit][3 tag bits] 
-So assuming the tag is 5, the tagged non-zero bit patterns are 
-             0x0000,0000,0000,001[d/5] 
-to           0xffff,ffff,ffff,fff[d/5] 
-and +/- 0d is 0x0000,0000,0000,000[d/5] 
-Encode/decode of non-zero values in machine code looks like: 
-						msb                                              lsb 
-Decode:				[8expsubset][52mantissa][1s][3tags] 
-shift away tags:			[ 000 ][8expsubset][52mantissa][1s] 
-add exponent offset:	[     11 exponent     ][52mantissa][1s] 
+Representation for immediate doubles, only used in the 64-bit implementation. Immediate doubles have the same 52 bit mantissa as IEEE double-precision  floating-point, but only have 8 bits of exponent.  So they occupy just less than the middle 1/8th of the double range.  They overlap the normal single-precision floats which also have 8 bit exponents, but exclude the single-precision denormals (exponent-127) and the single-precsion NaNs (exponent +127).  +/- zero is just a pair of values with both exponent and mantissa 0.
+So the non-zero immediate doubles range from
+        +/- 0x3800,0000,0000,0001 / 5.8774717541114d-39
+to      +/- 0x47ff,ffff,ffff,ffff / 6.8056473384188d+38
+The encoded tagged form has the sign bit moved to the least significant bit, which allows for faster encode/decode because offsetting the exponent can't overflow into the sign bit and because testing for +/- 0 is an unsigned compare for <= 0xf:
+    msb                                                                                        lsb
+    [8 exponent subset bits][52 mantissa bits ][1 sign bit][3 tag bits]
+So assuming the tag is 5, the tagged non-zero bit patterns are
+             0x0000,0000,0000,001[d/5]
+to           0xffff,ffff,ffff,fff[d/5]
+and +/- 0d is 0x0000,0000,0000,000[d/5]
+Encode/decode of non-zero values in machine code looks like:
+						msb                                              lsb
+Decode:				[8expsubset][52mantissa][1s][3tags]
+shift away tags:			[ 000 ][8expsubset][52mantissa][1s]
+add exponent offset:	[     11 exponent     ][52mantissa][1s]
 rot sign:				[1s][     11 exponent     ][52mantissa]
 
-Encode:					[1s][     11 exponent     ][52mantissa] 
-rot sign:				[     11 exponent     ][52mantissa][1s] 
-sub exponent offset:	[ 000 ][8expsubset][52 mantissa][1s] 
-shift:					[8expsubset][52 mantissa][1s][ 000 ] 
-or/add tags:			[8expsubset][52mantissa][1s][3tags] 
-but is slower in C because 
-a) there is no rotate, and 
-b) raw conversion between double and quadword must (at least in the source) move bits through memory ( quadword = *(q64 *)&doubleVariable). 
+Encode:					[1s][     11 exponent     ][52mantissa]
+rot sign:				[     11 exponent     ][52mantissa][1s]
+sub exponent offset:	[ 000 ][8expsubset][52 mantissa][1s]
+shift:					[8expsubset][52 mantissa][1s][ 000 ]
+or/add tags:			[8expsubset][52mantissa][1s][3tags]
+but is slower in C because
+a) there is no rotate, and
+b) raw conversion between double and quadword must (at least in the source) move bits through memory ( quadword = *(q64 *)&doubleVariable).
 
 
 Heap Walking
 In heap walking the memory manager needs to be able to detect the start of the next object.  This is complicated by the short and long header formats, short being for objects with 254 slots or less, long being for objects with 255 slots or more.  Since an object that has an overflow header must have 255 as its header slot count we can use this as the marker.  The overflow header word also has a numSlots field, set to 255.  The remainder of the overflow size field is used for the object's slot size, the least significant word in 32-bits (for 2^34 bytes, more than the address space), the remaining 56 bits in 64-bits (for 2^59 bytes, which we hope is big enough for bridge objects).  So if the word following an object contains 255 in its numSlots field, it must be the overflow size word of an object with a double header, and the word after that is the header, also with a saturated numSlots field.
 
-Total Number of Classes and Instance-specific Behaviours
-While the class index header field has advantages (saving significant header space, especially in 64-bits, providing a non-moving cache tag for inline caches, small constants for instantiating well-known classes instead of having to fetch them from a table such as the specialObjectsArray) it has the downside of limiting the number of classes.  For Smalltalk programs 2^20 to 2^24 classes is adequate for some time to come, but for prototype languages such as JavaScript this is clearly inadequate, and we woud like to support the ability to host prototype languages within Squeak. There is a solution in the form of "auto-instances", an idea of Claus Gittinger's.  The idea is to represent prototypes as behaviors that are instances of themselves.  In a classical Smalltalk system a Behavior is an object with the minimal amount of state to function as a class, and in Smalltalk-80 this state is the three instance variables of Behavior, superclass, methodDict and format, which are the only fields in a Behavior that are known to the virtual machine.  A prototype can therefore have its own behavior and inherit from other prototypes or classes, and have sub-prototypes derived from it if a) its first three instance variables are also superclass, methodDict, and format, and b) it is an instance of itself (one can create such objects in a normal Smalltalk system by creating an Array with the desired layout and using a change class primitive to change the class of the Array to itself).  The same effect can be achieved in a VM with class indexes by reserving one class index to indicate that the object is an instance of itself, hence not requiring the object be entered into the class table and in the code that derives the class of an object, requiring one simple test answering the object itself instead of indexing the class table.  There would probably need to be an auto-instantiation primitive that takes a behavior (or prototype) and an instance variable count and answers a new auto-instance with as many instance variables as the sum of the behavior (or prototype) and the instance variable count.  Using this scheme there can be as many auto-instances as available address space allows while retaining the benefits of class indices.
+Total Number of Classes and Instance-specific Behaviors
+While the class index header field has advantages (saving significant header space, especially in 64-bits, providing a non-moving cache tag for inline caches, small constants for instantiating well-known classes instead of having to fetch them from a table such as the specialObjectsArray) it has the downside of limiting the number of classes.  For Smalltalk programs 2^20 to 2^24 classes is adequate for some time to come, but for prototype languages such as JavaScript this is clearly inadequate, and we would like to support the ability to host prototype languages within Squeak. There is a solution in the form of "auto-instances", an idea of Claus Gittinger's.  The idea is to represent prototypes as behaviors that are instances of themselves.  In a classical Smalltalk system a Behavior is an object with the minimal amount of state to function as a class, and in Smalltalk-80 this state is the three instance variables of Behavior, superclass, methodDict and format, which are the only fields in a Behavior that are known to the virtual machine.  A prototype can therefore have its own behavior and inherit from other prototypes or classes, and have sub-prototypes derived from it if a) its first three instance variables are also superclass, methodDict, and format, and b) it is an instance of itself (one can create such objects in a normal Smalltalk system by creating an Array with the desired layout and using a change class primitive to change the class of the Array to itself).  The same effect can be achieved in a VM with class indexes by reserving one class index to indicate that the object is an instance of itself, hence not requiring the object be entered into the class table and in the code that derives the class of an object, requiring one simple test answering the object itself instead of indexing the class table.  There would probably need to be an auto-instantiation primitive that takes a behavior (or prototype) and an instance variable count and answers a new auto-instance with as many instance variables as the sum of the behavior (or prototype) and the instance variable count.  Using this scheme there can be as many auto-instances as available address space allows while retaining the benefits of class indices.
 
 This scheme has obvious implications for the inline cache since all prototypes end up having the same inline cache tag.  Either the inline cache check checks for the auto-instance class tag and substitutes the receiver, or the cacheing machinery refuses to add the auto-instance class tag to any inline cache and failure path code checks for the special case.  Note that in V8 failing monomorphic sends are patched to open PICs (megamorphic sends); V8 does not use closed PICs due to the rationale that polymorphism is high in JavaScript.
 
 Miscellanea
 In-line cache probe for immediates
-We would like to keep 31-bit SmallIntegers for the 32-bit system.  Lots of code could be impacted by a change to 30-bit SmallIntegers.  If so, then 
+We would like to keep 31-bit SmallIntegers for the 32-bit system.  Lots of code could be impacted by a change to 30-bit SmallIntegers.  If so, then
 	isImmediate: oop	^(oop bitAnd: 3) ~= 0
 	isSmallInteger: oop	^(oop bitAnd: 1) ~= 0
 	isCharacter: oop	^(oop bitAnd: 2) = 2


### PR DESCRIPTION
fix some typos in mc/VMMaker.oscog.package/SpurMemoryManager.class/README.md
