### PR TITLE
FilePlugin for Windows: Try to remove the read-only attribute of a fi…

### DIFF
--- a/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
+++ b/platforms/win32/plugins/FilePlugin/sqWin32FilePrims.c
@@ -17,7 +17,11 @@
 *
 *   UPDATES:
 *     1) Support for long path names added by using UNC prefix in that case
-*        (Marcel Taeumel, Hasso Plattner Institute, Postdam, Germany)
+*        (Marcel Taeumel, Hasso Plattner Institute, Potsdam, Germany)
+*     2) Try to remove the read-only attribute from a file before calling
+*        DeleteFile. DeleteFile cannot delete read-only files (see comment
+*        in sqFileDeleteNameSize).
+*        (Max Leske)
 *
 *****************************************************************************/
 #include <windows.h>
@@ -120,6 +124,21 @@ sqInt sqFileDeleteNameSize(char* fileNameIndex, sqInt fileNameSize) {
 
   if(hasCaseSensitiveDuplicate(win32Path))
     FAIL();
+  /*
+    DeleteFile will not delete a file with the read-only attribute set
+    (e.g. -r--r--r--, see https://msdn.microsoft.com/en-us/library/windows/desktop/aa363915(v=vs.85).aspx).
+    To ensure that this works the same way as on *nix platforms we need to
+    remove the read-only attribute (which might fail if the current user
+    doesn't own the file).
+
+    Also note that DeleteFile cannot *effectively* delete a file as long as
+    there are other processes that hold open handles to that file. The function
+    will still report success since the file is *marked* for deletion (no new
+    handles can be opened. See the URL mentioned above for reference).
+    This will lead to problems during a recursive delete operation since now
+    the parent directory wont be empty.
+  */
+  SetFileAttributesW(win32Path, FILE_ATTRIBUTE_NORMAL);
   if(!DeleteFileW(win32Path))
     FAIL();
   


### PR DESCRIPTION
…le before calling DeleteFile. DeleteFile cannot delete read-only files.
