### PR TITLE
Fixing the implementation of sqResolverLocalAddress to relagate in th…

### DIFF
--- a/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
+++ b/platforms/unix/plugins/SocketPlugin/sqUnixSocket.c
@@ -1488,55 +1488,12 @@ sqInt sqResolverStatus(void)
 sqInt sqResolverAddrLookupResultSize(void)	{ return strlen(lastName); }
 sqInt sqResolverError(void)			{ return lastError; }
 sqInt sqResolverLocalAddress(void)
-#if 0 
-/* old code */
 {	sqInt localaddr = nameToAddr(localHostName);
 	if (!localaddr)
 		localaddr = nameToAddr("localhost");
 	return localaddr;
 }
-#else
-/* experimental new code */
-{
-    struct ifaddrs *ifaddr, *ifa;
-    int s;
-    char host[NI_MAXHOST];
-    sqInt localAddr = 0;
 
-    if (getifaddrs(&ifaddr) == -1) {
-        interpreterProxy->success(false);
-        return 0;
-    }
-
-
-    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) 
-    {
-        if (ifa->ifa_addr == NULL)
-            continue;  
-
-        s=getnameinfo(ifa->ifa_addr,sizeof(struct sockaddr_in),host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
-
-        if(((strcmp(ifa->ifa_name,"eth0")==0)||(strcmp(ifa->ifa_name,"wlan0")==0))&&(ifa->ifa_addr->sa_family==AF_INET))
-        {
-            if (s != 0)
-            {
-                interpreterProxy->success(false);
-                return 0;
-            }
-            FPRINTF((stderr, "\tInterface : <%s>\n",ifa->ifa_name ));
-            FPRINTF((stderr, "\t IP       : <%s>\n", inet_ntoa(((struct sockaddr_in *)(ifa->ifa_addr))->sin_addr)));
-            if(localAddr == 0) { /* take the first plausible answer */
-                localAddr = ((struct sockaddr_in *)(ifa->ifa_addr))->sin_addr.s_addr;
-            }
-           
-        }
-    }
-
-    freeifaddrs(ifaddr);
-    return ntohl(localAddr);
-
-}
-#endif
 sqInt sqResolverNameLookupResult(void)		{ return lastAddr; }
 
 void sqResolverAddrLookupResult(char *nameForAddress, sqInt nameSize)


### PR DESCRIPTION
Delegating to the operating system for the address of the host. It resolves the address using the hostname of the machine. 

Previously was trying to get the address from the interfaces, and this was only working in some linuxes, because it was depending on the name of the interfaces (looking for exactly for "eth0" or "wlan0") and this was only working if the configuration was exactly like that. 

The implementation is the on previously used, it uses the hostname of the machine and then lookup the IP address assigned to this address. 
