### PR TITLE
fix bad path manipulation in Mac VM

### DIFF
--- a/platforms/iOS/vm/OSX/sqMacUnixExternalPrims.m
+++ b/platforms/iOS/vm/OSX/sqMacUnixExternalPrims.m
@@ -113,7 +113,7 @@ tryLoading(NSString *dirNameString, char *moduleName)
 	NSString    *libName;
 	
 	libName = [dirNameString stringByAppendingPathComponent: [NSString stringWithUTF8String: moduleName]];
-	libName = [libName stringByAppendingPathExtension: @"bundle/Contents/MacOS/"];
+	libName = [libName stringByAppendingPathComponent: @"bundle/Contents/MacOS/"];
 	libName = [libName stringByAppendingPathComponent: [NSString stringWithUTF8String: moduleName]];
 	handle = tryLoadingInternals(libName);
 	if (handle) 


### PR DESCRIPTION
We should have been using `-[NSString stringByAppendingPathComponent:]`, not `-[NSString stringByAppendingPathExtension:]`. The latter is truly just for extensions (e.g. `.doc` or `.app`); the former is for path concatenation. This didn't matter until Sierra, but they appear to have added better (probably any?) error checking to their functions to make sure they're used properly.

I'd note that I cannot at the moment actually check this change, because I'm in a catch-22 where I can't build the VM without a working VM, and my VM isn't working because it needs (I think) this patch applied. If someone has an El Capitan machine handy to do a build, I'd be happy to verify the fix works as intended.
