### PR TITLE
freebsd: Add necessary fields for AMD64 on FreeBSD

### DIFF
--- a/opensmalltalk-vm/platforms/unix/vm/sqUnixMain.c
+++ b/opensmalltalk-vm/platforms/unix/vm/sqUnixMain.c
@@ -885,6 +885,9 @@ reportStackState(char *msg, char *date, int printAll, ucontext_t *uap)
 # elif __FreeBSD__ && __i386__
 			void *fp = (void *)(uap ? uap->uc_mcontext.mc_ebp: 0);
 			void *sp = (void *)(uap ? uap->uc_mcontext.mc_esp: 0);
+# elif __FreeBSD__ && __amd64__
+			void *fp = (void *)(uap ? uap->uc_mcontext.mc_rbp: 0);
+			void *sp = (void *)(uap ? uap->uc_mcontext.mc_rsp: 0);
 # elif __OpenBSD__
 			void *fp = (void *)(uap ? uap->sc_rbp: 0);
 			void *sp = (void *)(uap ? uap->sc_rsp: 0);

--- a/opensmalltalk-vm/platforms/unix/vm/sqUnixVMProfile.c
+++ b/opensmalltalk-vm/platforms/unix/vm/sqUnixVMProfile.c
@@ -173,6 +173,8 @@ pcbufferSIGPROFhandler(int sig, siginfo_t *info, ucontext_t *uap)
 # define _PC_IN_UCONTEXT uc_mcontext.arm_pc
 #elif __FreeBSD__ && __i386__
 # define _PC_IN_UCONTEXT uc_mcontext.mc_eip
+#elif __FreeBSD__ && __amd64__
+# define _PC_IN_UCONTEXT uc_mcontext.mc_rip
 #elif __OpenBSD__
 # define _PC_IN_UCONTEXT sc_rip
 #else


### PR DESCRIPTION
Access the rpb/rsp and rip registers on FreeBSD/AMD64