### PR TITLE
debian: mkNamedPrims.sh is now in the root and properly found

### DIFF
--- a/packaging/pharo5-vm-core/debian/rules
+++ b/packaging/pharo5-vm-core/debian/rules
@@ -29,7 +29,6 @@ export LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
 
 override_dh_auto_configure:
 	mkdir -p build/debian/build
-	cp build.linux32x86/mkNamedPrims.sh build/
 	cp build.linux32x86/pharo.cog.spur/plugins.* build/debian/build/
 	dh_auto_configure -- \
 		--without-npsqueak \


### PR DESCRIPTION
With the latest buildsystem fixes we don't need to copy these files
anymore. Stop the failing copying.