### PR TITLE
travis-ci/debian: Build and upload source package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
       - libtool
       - automake
       - autoconf
+      - dpkg-dev
+      - osc
 matrix:
   include:
     - os: osx
@@ -35,7 +37,13 @@ matrix:
       osx_image: xcode6.4
       env: ARCH="macos64x64" FLAVOR="pharo.cog.spur" SRC_ARCH="x86_64"
     - os: linux
-      env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" SRC_ARCH="i386" HEARTBEAT="threaded"
+      env:
+      - ARCH="linux32x86"
+      - FLAVOR="pharo.cog.spur"
+      - SRC_ARCH="i386"
+      - HEARTBEAT="threaded"
+      - secure: "Irxld8P+3z61Q2/5ju3NLEVrj4uQJFJ/oTuKScqO4eLADYuUZUru6jhqZ1RkQWi+eOjJTiHGCKZI5lEZ4mrSa1VCFgOXlTfkTA8+eQYwCoaNM7dqTdzEAkSSX94FlzTf5+AyJTMjtDl2Wjitt1RXDNv3atcMIYx569unHr+7c4k="
+      - secure: "GoRhWin9A5beT7vD2DJcu2hsakYxgpa7dWHe1xzhbmCOykxLeORX2SKZtSwm3lbGsEp7RS+ldy6FeOcuRvZS11V0bEj1mXw8vspYHij9rHRbGKfE1zpR7djc7mUlt5oa+ycfgsO8pBdLENMvLwSD+qeuL+0P1LApnzw9K3xIRVg="
       addons:
         apt:
           packages:
@@ -56,7 +64,11 @@ matrix:
           - libglapi-mesa:i386
           - gcc-multilib
           - uuid-dev:i386
-      #after_script: (cd scripts; ./commit-sources.sh)
+      after_script:
+#      - (cd scripts; ./commit-sources.sh)
+      - make -f Makefile.debian version_from_travis
+      - make -f Makefile.debian
+      - ./scripts/commit-obs.sh
       after_deploy: ./scripts/deploy-after.sh
     - os: linux
       env: ARCH="linux32x86" FLAVOR="pharo.cog.spur" SRC_ARCH="i386" HEARTBEAT="itimer"

--- a/Makefile.debian
+++ b/Makefile.debian
@@ -1,5 +1,10 @@
+VER=`head -1 debian/changelog | cut -d ' ' -f 2 | sed s,"(","",  | sed s,")","",`
+
+
 all: build_srcpackage pharo5_sources
 
+version_from_travis:
+	cd packaging/pharo5-vm-core && dch -v $(VER).$(TRAVIS_JOB_NUMBER) -m "Travis build $(TRAVIS_JOB_NUMBER)"
 
 build_srcpackage:
 	@echo "Generating sources"

--- a/scripts/commit-obs.sh
+++ b/scripts/commit-obs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+if [ "${TRAVIS_BRANCH}" != "master" ]; then
+    echo "Only pushing changes on master and not ${TRAVIS_BRANCH}"
+    exit 0
+fi
+
+cat <<- EOF > ~/.oscrc
+[general]
+apiurl = https://api.opensuse.org
+
+[https://api.opensuse.org]
+user = ${OBS_USER}
+pass = ${OBS_PASS}
+EOF
+
+OBS_PACKAGE="pharo5"
+
+OBS_HOME="devel:languages:pharo:latest"
+
+# the project is always created via web or cli
+osc co ${OBS_HOME} ${OBS_PACKAGE}
+
+pushd .
+# rm files if directory is not empty
+cd ${OBS_HOME}/${OBS_PACKAGE}
+if [ `ls | wc -l` != 0 ]; then
+    osc rm *.dsc *.tar.gz
+fi
+popd
+
+# copy our new files and send them to obs
+cp packaging/*.dsc packaging/*.tar.gz ${OBS_HOME}/${OBS_PACKAGE}
+cd ${OBS_HOME}/${OBS_PACKAGE}
+osc add *.dsc *.tar.gz
+osc ci -v -m "new build ${TRAVIS_COMMIT_RANGE}"


### PR DESCRIPTION
Update the changelog to indicate the travis-ci build number, build
the sourcepackage and then upload it. The script expects OBS_USER
and OBS_PASS to be exported.