### PR TITLE
travis-ci/debian: Install osc in the right section of the matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
       - automake
       - autoconf
       - dpkg-dev
-      - osc
 matrix:
   include:
     - os: osx
@@ -64,6 +63,7 @@ matrix:
           - libglapi-mesa:i386
           - gcc-multilib
           - uuid-dev:i386
+          - osc
       after_script:
 #      - (cd scripts; ./commit-sources.sh)
       - make -f Makefile.debian version_from_travis


### PR DESCRIPTION
The packages section in the matrix build is replacing the global one,
add osc to the right list.