### PR TITLE
travis-ci/debian: Remove env vars, fix osc upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,6 @@ matrix:
       - FLAVOR="pharo.cog.spur"
       - SRC_ARCH="i386"
       - HEARTBEAT="threaded"
-      - secure: "Irxld8P+3z61Q2/5ju3NLEVrj4uQJFJ/oTuKScqO4eLADYuUZUru6jhqZ1RkQWi+eOjJTiHGCKZI5lEZ4mrSa1VCFgOXlTfkTA8+eQYwCoaNM7dqTdzEAkSSX94FlzTf5+AyJTMjtDl2Wjitt1RXDNv3atcMIYx569unHr+7c4k="
-      - secure: "GoRhWin9A5beT7vD2DJcu2hsakYxgpa7dWHe1xzhbmCOykxLeORX2SKZtSwm3lbGsEp7RS+ldy6FeOcuRvZS11V0bEj1mXw8vspYHij9rHRbGKfE1zpR7djc7mUlt5oa+ycfgsO8pBdLENMvLwSD+qeuL+0P1LApnzw9K3xIRVg="
       addons:
         apt:
           packages:

--- a/scripts/commit-obs.sh
+++ b/scripts/commit-obs.sh
@@ -10,6 +10,7 @@ fi
 cat <<- EOF > ~/.oscrc
 [general]
 apiurl = https://api.opensuse.org
+use_keyring = 0
 
 [https://api.opensuse.org]
 user = ${OBS_USER}
@@ -27,12 +28,13 @@ pushd .
 # rm files if directory is not empty
 cd ${OBS_HOME}/${OBS_PACKAGE}
 if [ `ls | wc -l` != 0 ]; then
-    osc rm *.dsc *.tar.gz
+    osc rm *.dsc
+    osc rm *.tar.*
 fi
 popd
 
 # copy our new files and send them to obs
-cp packaging/*.dsc packaging/*.tar.gz ${OBS_HOME}/${OBS_PACKAGE}
+cp packaging/pharo5-vm-*.dsc packaging/pharo5-vm-*.tar.* ${OBS_HOME}/${OBS_PACKAGE}
 cd ${OBS_HOME}/${OBS_PACKAGE}
-osc add *.dsc *.tar.gz
+osc add *.dsc *.tar.*
 osc ci -v -m "new build ${TRAVIS_COMMIT_RANGE}"


### PR DESCRIPTION
Fix the uploading of VM source packages. The environment variables
have been moved to the travis-ci configuration, disable keyring
support to use the username/password we set in the config. Only
copy the pharo5-vm code (and not the sources).