### PR TITLE
debian: Correct/add more symlinks for the Pharo6 images

### DIFF
--- a/Makefile.debian
+++ b/Makefile.debian
@@ -21,5 +21,5 @@ build_srcpackage:
 pharo6_sources:
 	cd packaging/pharo6-sources-files && wget http://files.pharo.org/sources/PharoV60.sources.zip
 	cd packaging/pharo6-sources-files && unzip PharoV60.sources.zip
-	cd packaging/pharo6-sources-files && rm PharoV60.sources.zip
+	cd packaging/pharo6-sources-files && rm -rf PharoV60.sources.zip __MACOSX
 	cd packaging/pharo6-sources-files && dpkg-buildpackage -S -uc -us -d

--- a/packaging/pharo6-sources-files/debian/changelog
+++ b/packaging/pharo6-sources-files/debian/changelog
@@ -1,4 +1,10 @@
-pharo6-sources-files (1) UNRELEASED; urgency=medium
+pharo6-sources-files (2) unstable; urgency=medium
+
+  * Add symlinks for the new i386/amd64 directories
+
+ -- Holger Hans Peter Freyther <holger@moiji-mobile.com>  Tue, 20 Jun 2017 17:19:28 +0200
+
+pharo6-sources-files (1) unstable; urgency=medium
 
   * Initial release
 

--- a/packaging/pharo6-sources-files/debian/pharo6-sources-files.links
+++ b/packaging/pharo6-sources-files/debian/pharo6-sources-files.links
@@ -1,4 +1,5 @@
 # Being arch-independent, the *.sources files must be in the
 # /usr/share directory but the VM requires these files to be in the
 # same directory as itself.
-usr/share/pharo6-vm/PharoV60.sources usr/lib/pharo6-vm/PharoV60.sources
+usr/share/pharo6-vm/PharoV60.sources usr/lib/i386-linux-gnu/pharo6-vm/PharoV60.sources
+usr/share/pharo6-vm/PharoV60.sources usr/lib/x86_64-linux-gnu/pharo6-vm/PharoV60.sources


### PR DESCRIPTION
The VM will look at the directory of the VM or the image. We didn't
have a symlink in the directory of the VMs. Fix that.